### PR TITLE
fix(logging): use fmt.Sprintln instead

### DIFF
--- a/logging/structured_logging.go
+++ b/logging/structured_logging.go
@@ -52,7 +52,8 @@ func (lg *Logger) printf(serverity, format string, v ...interface{}) {
 }
 
 func (lg *Logger) println(serverity string, v ...interface{}) {
-	lg.logger.Println(lg.fmtString(serverity, fmt.Sprint(v...)))
+	s := fmt.Sprintln(v...)
+	lg.logger.Println(lg.fmtString(serverity, s[:len(s)-1]))
 }
 
 func (lg *Logger) fmtString(serverity, msg string) string {

--- a/logging/structured_logging_test.go
+++ b/logging/structured_logging_test.go
@@ -1,0 +1,20 @@
+package logging_test
+
+import (
+	"github.com/TeamMomentum/go-pkg/logging"
+	"os"
+)
+
+func ExamplePrintln_empty() {
+	logging.SetOutput(os.Stdout)
+
+	logging.Println()
+	// Output: {"severity":"INFO"}
+}
+
+func ExamplePrintln_hello_world() {
+	logging.SetOutput(os.Stdout)
+
+	logging.Println("hello", "world")
+	// Output: {"severity":"INFO","message":"hello world"}
+}


### PR DESCRIPTION
## Before

```go
	logging.Println("hello", "world")
	// Output: {"severity":"INFO","message":"helloworld"}
```

## After

```go
	logging.Println("hello", "world")
	// Output: {"severity":"INFO","message":"hello world"}
```